### PR TITLE
The paragraph "package default" shouldn't be added when rendering

### DIFF
--- a/src/Views/Partials/Tables/default.cshtml
+++ b/src/Views/Partials/Tables/default.cshtml
@@ -10,7 +10,7 @@
     var columnHasHeader = Model.Settings.ColumnHasHeader;
     var rowHasHeader = Model.Settings.RowHasHeader;
 }
-<p>Package Default</p>
+
 <table class="ww-table">
     
     @* ─────────────────────────────


### PR DESCRIPTION
When doing the default render I see `Package Default` above each table, think that's a bit of debugging that was left behind.

<img width="908" height="352" alt="image" src="https://github.com/user-attachments/assets/774c5e10-1e85-4ac8-9d42-6cba9583a8de" />
